### PR TITLE
Making some essential updates to the HacSoc page

### DIFF
--- a/app/views/hacsoc/index.haml
+++ b/app/views/hacsoc/index.haml
@@ -1,19 +1,23 @@
 %h1.root HacSoc
 :markdown
-  Hacker Society (HacSoc) is a group associated with the CWRU ACM chapter dedicated to developing
-  the skills needed to actually produce real world software in its members.
-  HacSoc hosts weekly tech talks with topics ranging from systems level security
-  up to introducing the new features of HTML5 and even talks about the legal side
-  of intellectual property.  Speakers have been students, professionals from industry,
-  and occasionally professors. For more information about Hacker Society, check out
-  [our website](http://www.hacsoc.org "HacSoc Website"). 
+  Hacker Society (HacSoc) is the parent organization of the CWRU ACM
+  chapter. We are dedicated to developing the skills needed to actually
+  produce real world software in its members. HacSoc hosts weekly tech talks
+  with topics ranging from systems level security up to introducing the new
+  features of HTML5 and even talks about the legal side of intellectual
+  property.  Speakers have been students, professionals from industry, and
+  occasionally professors. For more information about Hacker Society, check
+  out [our website](http://www.hacsoc.org "HacSoc Website"). 
 
 %h2 Projects
 :markdown
-  Right now, the best way to keep up with current HacSoc projects is to join
-  either of our mailing lists: [CWRU Hackers](https://lists.case.edu/wws/info/cwru-hackers)
-  for general body information and [Hackers Discuss](https://lists.case.edu/wws/info/hackers-discuss)
-  for club discussion. Much of our past work is hosted on
-  [our Github organization](https://github.com/hacsoc "HacSoc Github"), including
-  this website. If you're a CWRU student and want to get involved with our work,
-  contact the current organizer of HacSoc [Brendan Higgins](mailto:bjh83@case.edu) with any questions. 
+  Right now, the best way to keep up with current HacSoc projects is to
+  join either of our mailing lists: [CWRU
+  Hackers](https://lists.case.edu/wws/info/cwru-hackers) for general body
+  announcements and [Hackers
+  Discuss](https://lists.case.edu/wws/info/hackers-discuss) for club
+  discussion. Much of our past work is hosted on [our Github
+  organization](https://github.com/hacsoc "HacSoc Github"), including this
+  website. If you're a CWRU student and want to get involved with our work or
+  would like to contribute a talk, contact the current HacSoc maintainer and
+  president [Adam Gleichsner](mailto:amg188@case.edu) with any questions. 


### PR DESCRIPTION
This updates the description of HacSoc slightly and changes the mention of Brendan as organizer to Adam as president and maintainer.