### PR TITLE
Improving Call for Proposals, Google Form link for proposals

### DIFF
--- a/app/views/acm/conference/2015.haml
+++ b/app/views/acm/conference/2015.haml
@@ -45,14 +45,25 @@
 #callforspeakers
   %h2 Call for Speakers
   %br
-  We are seeking proposals from individuals with professional and
-  technical experience in any programming, computer, or electrical related
-  field to speak at Link-State 2015. We have had open source project
-  maintainers, engineers, designers, and students present at past conferences
-  and hope to represent as many computer-related fields as we can fit. Our
-  talks are 1-hour sessions, including Q&A, that take place in the lecture
-  spaces of the Agnar Pytte Science Center. Contact #{ mail_to "hacsoc-officers@case.edu", "the team", subject:"CWRU Hacker Society Link-State 2015 Speaking Opportunities" }
-  for more information or to submit a proposal.
+  We are seeking proposals to speak at Link-State 2015 from individuals with
+  professional and technical experience in any field that would be of benefit to
+  students interested in computer science, programming, computer or electrical
+  engineering. We have had open source project maintainers, engineers,
+  designers, and students present at past conferences and hope to represent as
+  many computer-related fields as we can fit. Our talks are 1-hour sessions,
+  including Q&A, that take place in the lecture spaces of the Agnar Pytte
+  Science Center. Contact #{ mail_to "hacsoc-officers@case.edu", "the team", subject:"CWRU Hacker Society Link-State 2015 Speaking Opportunities" }
+  for more information about speaking at Link-State 2015.
+  %br
+  %br
+  If you have a proposal for this year's conference, please fill out our
+  #{link_to("Google Form", "https://docs.google.com/a/case.edu/forms/d/13L04T0XnZs1QPfCFAoKr79Wu28YJ2rcp76o0FYoOOf8/viewform")}
+  and we will get back to you shortly!
+  %br
+  %br
+  We are also planning 5-15 minute Lightning Talks as part of the conference to
+  add variety from speakers who would prefer to commit to a smaller
+  presentation. Stay tuned for more information.
   
 -# TODO: Sponsors list, see: config/sponsors.yml, section sponsors_2015
 -# Be sure to put logos under public/images/sponsors_ls_2015


### PR DESCRIPTION
Reworded the opening of the Call for Proposals. This could probably use some editing.

Primarily, closing #44 by adding a link to our shiny new Google Form.

Finally, included a reminder to keep Lighting Talks in mind. We can publish details once we are working on schedule details.