### PR TITLE
Switch to using Google's short link for the Proposal form

### DIFF
--- a/app/views/acm/conference/2015.haml
+++ b/app/views/acm/conference/2015.haml
@@ -57,7 +57,7 @@
   %br
   %br
   If you have a proposal for this year's conference, please fill out our
-  #{link_to("Google Form", "https://docs.google.com/a/case.edu/forms/d/13L04T0XnZs1QPfCFAoKr79Wu28YJ2rcp76o0FYoOOf8/viewform")}
+  #{link_to("Google Form", "https://goo.gl/forms/YKNRyJlEPc")}
   and we will get back to you shortly!
   %br
   %br


### PR DESCRIPTION
Minor cleanup to make copying the link a bit better.